### PR TITLE
Fix au_GetLatest not calling when package is pushed via [PUSH $package]

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -86,7 +86,7 @@ build_script:
                     $package_dir = ls -recurse | ? { $_.Name -eq "$package.nuspec"} | select -First 1 | % Directory
                     if (!$package_dir) { Write-Warning "Can't find package '$package'"; continue }
                     pushd $package_dir
-                      if (Test-Path update.ps1 -ea 0) { ./update.ps1 }
+                      if (Test-Path update.ps1 -ea 0) { $au_Force = $true; ./update.ps1 }
                       choco pack; Push-Package;
                     popd
                 }


### PR DESCRIPTION
Wihout `$au_Force`, when pushing version that is already present, `au_GetLatest` is not called, resulting, in example, in not embedding remote binaries [defined in au_GetLatest](https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/automatic/everything/update.ps1#L22), therefore building and pushing incompletely package.