### PR TITLE
Remove usage of WMF 5 AppVeyor Image

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,7 +2,6 @@
 
 version: '{build}'
 max_jobs: 1
-image: WMF 5
 # History plugin requires complete log
 #clone_depth: 5
 branches:


### PR DESCRIPTION
- The version of Chocolatey that is installed on this base image is very old
- It doesn't have the TLS update within it, which is resulting in a number of reported problems
- The Core Team Packages repository now uses the default AppVeyor image
  https://github.com/chocolatey/chocolatey-coreteampackages/blob/master/.appveyor.yml#L7