### PR TITLE
Clarify PowerShell requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The repository is setup so that you can manage your packages entirely from the G
 
 To run locally you will need:
 
-- Powershell 5+.
+- Powershell `5.x` (AU does not support PowerShell 6+).
 - [Chocolatey Automatic Package Updater Module](https://github.com/majkinetor/au): `Install-Module au` or `cinst au`.
 
 In order to setup AppVeyor update runner please take a look at the AU wiki [AppVeyor section](https://github.com/majkinetor/au/wiki/AppVeyor).


### PR DESCRIPTION
Made requirement more explicit, as `5+` can be interpreted as _any version greater than 5_.