### PR TITLE
Add gist_id_test to update_vars_default.ps1

### DIFF
--- a/update_vars_default.ps1
+++ b/update_vars_default.ps1
@@ -9,6 +9,7 @@ $Env:mail_enablessl   = 'true'
 
 $Env:api_key          = ''          #Chocolatey api key
 $Env:gist_id          = ''          #Specify your gist id or leave empty for anonymous gist
+$Env:gist_id_test     = ''          #Specify your gist id for test runs or leave empty for anonymous gist
 $Env:github_user_repo = ''          #{github_user}/{repo}
 $Env:github_api_key   = ''          #Github personal access token
 $Env:au_Push          = 'false'     #Push to chocolatey


### PR DESCRIPTION
As a new user it threw me off that $Env:gist_id_test isn't set in the file and there is no error message stating this. When e.g. using `test_all.ps1` `gist_id_test` is used instead of `gist_id`